### PR TITLE
Check if model attribute with name given by group_name corresponds to a list before adding to that list

### DIFF
--- a/lems/run.py
+++ b/lems/run.py
@@ -41,12 +41,25 @@ def process_args():
     
     return parser.parse_args()
 
-def main():
+def run(file_path,include_dirs=[],dlems=False,nogui=False):
+    """
+    Function for running from a script or shell.
+    """
+    import argparse
+    args = argparse.Namespace()
+    args.lems_file = file_path
+    args.I = include_dirs
+    args.dlems = dlems
+    args.nogui = nogui
+    main(args=args)
+
+def main(args=None):
     """
     Program entry point.
     """
     
-    args = process_args()
+    if args is None:
+        args = process_args()
     
     print('Parsing and resolving model: '+args.lems_file)
     model = Model()

--- a/lems/sim/runnable.py
+++ b/lems/sim/runnable.py
@@ -187,6 +187,9 @@ class Runnable(Reflective):
         #print sorted(self.__dict__.keys())
         #print ".........."
         #print self.__dict__[group_name]
+        # Force group_name attribute to be a list before we append to it.
+        if type(self.__dict__[group_name]) is not list:
+            self.__dict__[group_name] = [self.__dict__[group_name]]
         self.__dict__[group_name].append(child)
         child.parent = self
 


### PR DESCRIPTION
52ffdca: 
Some models have attributes that are not lists, resulting in an error when we try to append to that list.  This commit converts the attribute to a list, if needed, before adding to it.  [Here](https://github.com/openworm/muscle_model/blob/master/NeuroML2/analyse_k_fast.sh) is an example of such a model, where the ChannelPopulation attribute was not a list, but ended up getting passed here.  I assume the original problem is upstream in libNeuroML, but I'm not sure where, and this commit is sufficient for getting that model to run in pylems.  

ed435e2:
I want to use pylems from inside my other scripts, and calling the pylems shell script is awkward, so I added the ability to run pylems directly via python by wrapping the main() function and creating a dummy argument parser filled from arguments to a new run() function.  