### PR TITLE
componentType instead of component in MultiInstantiate

### DIFF
--- a/lems/model/model.py
+++ b/lems/model/model.py
@@ -702,8 +702,12 @@ class Model(LEMSBase):
 
         for mi in ct.structure.multi_instantiates:
             try:
-                mi2 = MultiInstantiate(fc.component_references[mi.component].referenced_component,
-                                       int(fc.parameters[mi.number].numeric_value))
+                if mi.component:
+                    mi2 = MultiInstantiate(component=fc.component_references[mi.component].referenced_component,
+                                           number=int(fc.parameters[mi.number].numeric_value))
+                else:
+                    mi2 = MultiInstantiate(component_type=fc.component_references[mi.component_type].referenced_component,
+                                           number=int(fc.parameters[mi.number].numeric_value))                    
             except:
                 raise ModelError("Unable to resolve multi-instantiate parameters for "
                                  "'{0}' in component '{1}'",

--- a/lems/model/structure.py
+++ b/lems/model/structure.py
@@ -216,15 +216,19 @@ class MultiInstantiate(LEMSBase):
     Stores a child multi-instantiation specification.
     """
 
-    def __init__(self, component_type, number):
+    def __init__(self, component=None, component_type=None, number=None):
         """
         Constructor.
         
         See instance variable documentation for more details on parameters.
         """
 
-        self.component_type = component_type
+        self.component = component
         """ Name of the component reference to be used for instantiation.
+        @type: str """
+
+        self.component_type = component_type
+        """ Name of the component type reference to be used for instantiation.
         @type: str """
 
         self.number = number
@@ -237,7 +241,7 @@ class MultiInstantiate(LEMSBase):
         @type: list(Assign) """
         
     def __eq__(self, o):
-        return self.component_type == o.component_type and self.number == o.number
+        return self.component == o.component and self.number == o.number
         
     def add_assign(self, assign):
         """
@@ -264,13 +268,20 @@ class MultiInstantiate(LEMSBase):
         """
         Exports this object into a LEMS XML object
         """
+        argstr = ''
+        if self.component:
+            argstr += 'component="{0}" '.format(self.component)
+        if self.component_type:
+            argstr += 'componentType="{0}" '.format(self.component_type)
+        if self.number:
+            argstr += 'number="{0}" '.format(self.number)
         if self.assignments:
             chxmlstr = ''
             for assign in self.assignments:
                 chxmlstr += assign.toxml()
-            return '<MultiInstantiate componentType="{0}" number="{1}">{2}</MultiInstantiate>'.format(self.component_type, self.number, chxmlstr)
+            return '<MultiInstantiate {0}>{1}</MultiInstantiate>'.format(argstr, chxmlstr)
         else:
-            return '<MultiInstantiate componentType="{0}" number="{1}"/>'.format(self.component_type, self.number)
+            return '<MultiInstantiate {0}/>'.format(argstr)
 
 class ForEach(LEMSBase):
     """

--- a/lems/model/structure.py
+++ b/lems/model/structure.py
@@ -216,14 +216,14 @@ class MultiInstantiate(LEMSBase):
     Stores a child multi-instantiation specification.
     """
 
-    def __init__(self, component, number):
+    def __init__(self, component_type, number):
         """
         Constructor.
         
         See instance variable documentation for more details on parameters.
         """
 
-        self.component = component
+        self.component_type = component_type
         """ Name of the component reference to be used for instantiation.
         @type: str """
 
@@ -237,7 +237,7 @@ class MultiInstantiate(LEMSBase):
         @type: list(Assign) """
         
     def __eq__(self, o):
-        return self.component == o.component and self.number == o.number
+        return self.component_type == o.component_type and self.number == o.number
         
     def add_assign(self, assign):
         """
@@ -268,9 +268,9 @@ class MultiInstantiate(LEMSBase):
             chxmlstr = ''
             for assign in self.assignments:
                 chxmlstr += assign.toxml()
-            return '<MultiInstantiate component="{0}" number="{1}">{2}</MultiInstantiate>'.format(self.component, self.number, chxmlstr)
+            return '<MultiInstantiate componentType="{0}" number="{1}">{2}</MultiInstantiate>'.format(self.component_type, self.number, chxmlstr)
         else:
-            return '<MultiInstantiate component="{0}" number="{1}"/>'.format(self.component, self.number)
+            return '<MultiInstantiate componentType="{0}" number="{1}"/>'.format(self.component_type, self.number)
 
 class ForEach(LEMSBase):
     """

--- a/lems/model/structure.py
+++ b/lems/model/structure.py
@@ -216,7 +216,7 @@ class MultiInstantiate(LEMSBase):
     Stores a child multi-instantiation specification.
     """
 
-    def __init__(self, component=None, component_type=None, number=None):
+    def __init__(self, component=None, number=None, component_type=None):
         """
         Constructor.
         

--- a/lems/model/structure.py
+++ b/lems/model/structure.py
@@ -222,6 +222,10 @@ class MultiInstantiate(LEMSBase):
         
         See instance variable documentation for more details on parameters.
         """
+        if component and component_type:
+            raise AttributeError("MultiInstantiate should contain either"
+                                 " an attribute component or an attribute"
+                                 " component_type, not both.")
 
         self.component = component
         """ Name of the component reference to be used for instantiation.
@@ -241,8 +245,12 @@ class MultiInstantiate(LEMSBase):
         @type: list(Assign) """
         
     def __eq__(self, o):
-        return self.component == o.component and self.number == o.number
-        
+        if self.component:
+            flag = self.component == o.component and self.number == o.number
+        else:
+            flag = self.component_type == o.component_type and self.numbek4r == o.number
+        return flag
+
     def add_assign(self, assign):
         """
         Adds an Assign to the structure.


### PR DESCRIPTION
I found a bug in my recent update. There should be attribute `componentType` instead of `component` in MultiInstantiate.