### PR TITLE
More consistent use of debug messages

### DIFF
--- a/lems/__init__.py
+++ b/lems/__init__.py
@@ -8,4 +8,4 @@ import logging
 
 logger = logging.getLogger('LEMS')
 
-__version__ = '0.4.9'
+__version__ = '0.4.9.1'

--- a/lems/model/model.py
+++ b/lems/model/model.py
@@ -38,8 +38,8 @@ class Model(LEMSBase):
     #schema_location = '/home/padraig/LEMS/Schemas/LEMS/LEMS_v%s.xsd'%target_lems_version
     
     debug = False
-    
-    def __init__(self, include_includes='True'):
+    , 
+    def __init__(self, include_includes=True, fail_on_missing_includes=True):
         """
         Constructor.
         """
@@ -90,6 +90,10 @@ class Model(LEMSBase):
         
         self.include_includes = include_includes
         """ Whether to include LEMS definitions in <Include> elements
+        @type: boolean """
+        
+        self.fail_on_missing_includes = fail_on_missing_includes
+        """ Whether to raise an Exception when a file in an <Include> element is not found
         @type: boolean """
 
     def add_target(self, target):
@@ -247,8 +251,11 @@ class Model(LEMSBase):
                         else:
                             if self.debug: print("Already included: %s"%path)
                             return
-            if self.debug: print('Unable to open' + path)
-            #raise Exception('Unable to open ' + path)
+            msg = 'Unable to open ' + path
+            if self.fail_on_missing_includes:
+                raise Exception(msg)
+            elif self.debug: 
+                print(msg)
             
     def import_from_file(self, filepath):
         """

--- a/lems/model/model.py
+++ b/lems/model/model.py
@@ -247,7 +247,8 @@ class Model(LEMSBase):
                         else:
                             if self.debug: print("Already included: %s"%path)
                             return
-            raise Exception('Unable to open ' + path)
+            if self.debug: print('Unable to open' + path)
+            #raise Exception('Unable to open ' + path)
             
     def import_from_file(self, filepath):
         """

--- a/lems/parser/LEMS.py
+++ b/lems/parser/LEMS.py
@@ -999,7 +999,7 @@ class LEMSFileParser(LEMSBase):
         @raise ParseError: Raised when the file to be included is not specified. 
         """
         if not self.include_includes:
-            print("Ignoring included LEMS file: %s"%node.lattrib['file'])
+            if self.model.debug: print("Ignoring included LEMS file: %s"%node.lattrib['file'])
         else:
 
             #TODO: remove this hard coding for reading NeuroML includes...


### PR DESCRIPTION
A few of the exceptions and hard-coded print statements will now just print debug messages if debug is on.  In particular, there are scenarios where some of the included files will not be found, but this is OK (so better just to print a debug message than raise an exception and let the user decide).  