### PR TITLE
feat: enable parsing of model description

### DIFF
--- a/lems/parser/LEMS.py
+++ b/lems/parser/LEMS.py
@@ -271,11 +271,10 @@ class LEMSFileParser(LEMSBase):
 
         if xml.ltag != 'lems' and xml.ltag != 'neuroml':
             raise ParseError('<Lems> expected as root element (or even <neuroml>), found: {0}'.format(xml.ltag))
-        '''
+
         if xml.ltag == 'lems':
             if 'description' in xml.lattrib:
-                self.description = xml.lattrib['description']
-        '''
+                self.model.description = xml.lattrib['description']
 
         self.process_nested_tags(xml)
 


### PR DESCRIPTION
This was disabled, but I can't quite figure out why.

Question: should this also read descriptions from `<neuroml>` tags? Can they have description attributes?

@pgleeson: another one to review (can't assign us because I don't have the rights on LEMS repos from the looks of it)