### PR TITLE
fix: silently continue if typing module is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # Install flake
-        python -m pip install pytest
+        python -m pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Checkout NeuroML2
@@ -53,6 +53,8 @@ jobs:
 
     - name: Lint with flake8
       run: |
+        # Install flake
+        python -m pip install pytest
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/lems/model/model.py
+++ b/lems/model/model.py
@@ -7,7 +7,11 @@ Model storage.
 
 import os
 from os.path import dirname
-from typing import List, Dict
+# For python versions where typing isn't available at all
+try:
+    from typing import List, Dict
+except ImportError:
+    pass
 
 from lems import __schema_location__, __schema_version__
 from lems.base.base import LEMSBase


### PR DESCRIPTION
@pgleeson : this should ensure that it always works, all the typing imports are only used in comments, so are not required at runtime.