### PR TITLE
fix(parser): quote text in the description attribute

### DIFF
--- a/lems/model/component.py
+++ b/lems/model/component.py
@@ -13,6 +13,7 @@ from lems.model.dynamics import Dynamics
 from lems.model.structure import Structure
 from lems.model.simulation import Simulation
 from lems.parser.expr import ExprParser
+from xml.sax.saxutils import quoteattr
 
 class Parameter(LEMSBase):
     """
@@ -210,7 +211,7 @@ class DerivedParameter(LEMSBase):
 
         return '<DerivedParameter name="{0}"'.format(self.name) +\
           (' dimension="{0}"'.format(self.dimension) if self.dimension else '') +\
-          (' description="{0}"'.format(self.description) if self.description else '') +\
+          (' description={0}'.format(quoteattr(self.description) if self.description else '""')) +\
           (' value="{0}"'.format(self.value) if self.value else '') +\
           '/>'
 
@@ -424,7 +425,7 @@ class Children(LEMSBase):
         Exports this object into a LEMS XML object
         """
 
-        return '<{3} name="{0}" type="{1}" description="{2}"/>'.format(self.name, self.type, self.description, 'Children' if self.multiple else 'Child')
+        return '<{3} name="{0}" type="{1}" description={2}/>'.format(self.name, self.type, quoteattr(self.description) if self.description else '""', 'Children' if self.multiple else 'Child')
 
 class Text(LEMSBase):
     """
@@ -987,7 +988,7 @@ class ComponentType(Fat):
 
         xmlstr = '<ComponentType name="{0}"'.format(self.name) +\
           (' extends="{0}"'.format(self.extends) if self.extends else '') +\
-          (' description="{0}"'.format(self.description) if self.description else '')
+          (' description={0}'.format(quoteattr(self.description) if self.description else '""'))
 
         chxmlstr = ''
 

--- a/lems/model/model.py
+++ b/lems/model/model.py
@@ -27,6 +27,9 @@ from lems.model.simulation import Run,Record,EventRecord,DataDisplay,DataWriter,
 from lems.model.structure import With,EventConnection,ChildInstance,MultiInstantiate
 
 import xml.dom.minidom as minidom
+from xml.parsers.expat import ExpatError, errors
+from xml.sax.saxutils import quoteattr
+
 
 import logging
 
@@ -311,7 +314,12 @@ class Model(LEMSBase):
 
         xmlstr += '</Lems>'
 
-        xmldom = minidom.parseString(xmlstr)
+        try:
+            xmldom = minidom.parseString(xmlstr)
+        except ExpatError as er:
+            print("Parsing error:", errors.messages[er.code])
+            print("at: " + xmlstr[er.offset:er.offset+20])
+            raise
         return xmldom
 
     def export_to_file(self, filepath, level_prefix = '  '):


### PR DESCRIPTION
Descriptions can include `&quot; ..  &quot;` and when these are read,
they're converted to `" .."` internally. We need to make sure these are
escaped correctly so that when the internal XML string is passed to
parsers (like the minidom parser), it is still valid.

This was causing issues with `who called it &quot; Bonhoeffer-van der Pol model &quot;` in https://github.com/NeuroML/NeuroML2/blob/development/NeuroML2CoreTypes/Cells.xml#L1537

We should add more tests to the parser etc. too. 