### PR TITLE
Fix: Properly Parse 'symbol' and 'description' Attributes in LEMS Constant Element

### DIFF
--- a/lems/parser/LEMS.py
+++ b/lems/parser/LEMS.py
@@ -647,7 +647,14 @@ class LEMSFileParser(LEMSBase):
         else:
             description = None
 
-        constant = Constant(name, value, dimension, description)
+        if "symbol" in node.lattrib:
+            symbol = node.lattrib["symbol"]
+        else:
+            symbol = None
+
+        constant = Constant(
+            name, value, dimension=dimension, description=description, symbol=symbol
+        )
 
         if self.current_component_type:
             self.current_component_type.add_constant(constant)


### PR DESCRIPTION
This pull request addresses issue #77  in the LEMSFileParser where the 'symbol' and 'definition' attributes of the `<Constant>` element were not being parsed and stored correctly.

## Changes made:
- Introduced additional parsing for the symbol attribute within the parse_constant method. This involves extracting the symbol attribute's value from the XML node and handling cases where it might not be present:
```python
if "symbol" in node.lattrib:
    symbol = node.lattrib["symbol"]
else:
    symbol = None
```

- Modified the instantiation of the Constant object to include the newly parsed symbol attribute. The constructor now receives symbol as a key-value pair, ensuring that each attribute of the <Constant> element is accurately represented in the object
```python
constant = Constant(
    name, value, dimension=dimension, description=description, symbol=symbol
)
````
- These changes ensure that the symbol attribute, if present in the `<Constant>` element of the LEMS XML, is correctly parsed and assigned to the corresponding attribute of the Constant class in Python. This rectifies the previous issue where the description attribute was mistakenly assigned to the symbol attribute of the Constant object.

## Affected file(s):
- `lems/parser/LEMS.py`