### PR TITLE
Fix namespaced attributes

### DIFF
--- a/lems/model/model.py
+++ b/lems/model/model.py
@@ -369,7 +369,8 @@ class Model(LEMSBase):
             xmldom = minidom.parseString(xmlstr)
         except ExpatError as er:
             print("Parsing error:", errors.messages[er.code])
-            print("at: " + xmlstr[er.offset : er.offset + 20])
+            print("at: " + xmlstr[er.offset - 50: er.offset + 50])
+            print("at: " + ("-" * 50) + "^")
             raise
         return xmldom
 


### PR DESCRIPTION
Similar to namespaced tags, we also convert namespaced attributes into their corresponding ComponentTypes.

Otherwise, we get errors of this form:

```
Parsing error: not well-formed (invalid token)
    at: onent id="rdf_Description" type="rdf_Description" {http://www.w3.org/1999/02/22-rdf-syntax-ns}about=
    at: --------------------------------------------------^
Traceback (most recent call last):
  File "/home/asinha/Documents/02_Code/00_mine/models/Human-L2-3-Cortical-Microcircuit/NeuroML2/pyneuroml_20250205172314_LMX8TG/pyneuroml_20250205172314_LMX8TG_generated/../../nml_v2spikes.py", line 22, in <module>
    print(model.export_to_dom().toprettyxml())
          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/asinha/.local/share/virtualenvs/hl23/lib/python3.11/site-packages/lems/model/model.py", line 369, in export_to_dom
    xmldom = minidom.parseString(xmlstr)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/xml/dom/minidom.py", line 2000, in parseString
    return expatbuilder.parseString(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/xml/dom/expatbuilder.py", line 925, in parseString
    return builder.parseString(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/xml/dom/expatbuilder.py", line 223, in parseString
    parser.Parse(string, True)
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 1, column 10180222

```

A note here is that we lose namespace information, and if a loaded model is thus exported, it will be different from the imported text. Once the model has been loaded here, it has been "LEMSified", in the sense that it has been converted to LEMS's XML language, which does not support namespaces.

Thus, there should not be an expectation that a model loaded into PyLEMS will be exported in the same form. It will not.

I do not know if we want that to be the case. If we do, we will need to update our parsing to not strip out namespaces and so on.

I also have some queries regarding this code:

- I do not know why we first convert the XML to a DOM to then export it to XML: is the DOM used anywhere else?
- We seem to be mixing xml.ElementTree and xml.minidom here too: the `parse` method in LEMS.py uses ElementTree to load the XML text, but then creates the `LEMSXMLNode` of it to process it.
